### PR TITLE
Remove address sanitizer checks from CI

### DIFF
--- a/.github/workflows/sifis-td-ubuntu.yml
+++ b/.github/workflows/sifis-td-ubuntu.yml
@@ -221,12 +221,6 @@ jobs:
     - name: Run cargo-fuzz
       run: cargo fuzz build
 
-    - name: Run AddressSanitizer
-      env:
-        RUSTFLAGS: -Zsanitizer=address
-        RUSTDOCFLAGS: -Zsanitizer=address
-      run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu
-
   static-code-analysis:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
At the moment it creates more issue than it could solve, given that we don't have any `unsafe`.